### PR TITLE
Add Puppeter Options to generatePdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Alternatively, just compile the `index.ts` using `tsc`.
 > node ./basic-usage/index.js
 ```
 
+## Running in Docker
+If use tea-school in Docker you can pass to Puppeteer arguments.
+
+```ecmascript 6
+  const puppeteerOptions = {
+    args: [
+      // Required for Docker version of Puppeteer
+      '--no-sandbox',
+    ],
+  };
+  const pdfFile = await TeaSchool.generatePdf(teaSchoolOptions, puppeteerOptions);
+```
 ### Important
 The key `compiledStyle` is reserved on the Pug options for the compiled style to be attached to the html.  
 Please do not use this key (or use at your own risk)

--- a/README.md
+++ b/README.md
@@ -102,18 +102,6 @@ Alternatively, just compile the `index.ts` using `tsc`.
 > node ./basic-usage/index.js
 ```
 
-## Running in Docker
-If use tea-school in Docker you can pass to Puppeteer arguments.
-
-```ecmascript 6
-  const puppeteerOptions = {
-    args: [
-      // Required for Docker version of Puppeteer
-      '--no-sandbox',
-    ],
-  };
-  const pdfFile = await TeaSchool.generatePdf(teaSchoolOptions, puppeteerOptions);
-```
 ### Important
 The key `compiledStyle` is reserved on the Pug options for the compiled style to be attached to the html.  
 Please do not use this key (or use at your own risk)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,11 @@ namespace TeaSchool{
         htmlTemplatePath?: string;
         htmlTemplateOptions?: pug.Options & pug.LocalsObject;
         pdfOptions?: PDFOptions;
+        puppeteerOptions?: LaunchOptions;
     }
 
-    export const generatePdf = async (options: GeneratePdfOptions, puppeteerOptions?:LaunchOptions): Promise<Buffer> => {
-        const browser = await puppeteer.launch(puppeteerOptions);
+    export const generatePdf = async (options: GeneratePdfOptions): Promise<Buffer> => {
+        const browser = await puppeteer.launch(options.puppeteerOptions);
         const page = await browser.newPage();
         let htmlTemplateOptions: pug.Options & pug.LocalsObject = {...options.htmlTemplateOptions};
         let renderedTemplate;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as pug from 'pug';
 import * as sass from 'node-sass';
-import puppeteer, {NavigationOptions, PDFOptions} from 'puppeteer';
+import puppeteer, {LaunchOptions, NavigationOptions, PDFOptions} from 'puppeteer';
 import {Options as SassOptions} from 'node-sass';
 
 namespace TeaSchool{
@@ -12,8 +12,8 @@ namespace TeaSchool{
         pdfOptions?: PDFOptions;
     }
 
-    export const generatePdf = async (options: GeneratePdfOptions): Promise<Buffer> => {
-        const browser = await puppeteer.launch();
+    export const generatePdf = async (options: GeneratePdfOptions, puppeteerOptions?:LaunchOptions): Promise<Buffer> => {
+        const browser = await puppeteer.launch(puppeteerOptions);
         const page = await browser.newPage();
         let htmlTemplateOptions: pug.Options & pug.LocalsObject = {...options.htmlTemplateOptions};
         let renderedTemplate;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,58 +1,11 @@
 {
   "compilerOptions": {
-    /* Basic Options */
-    "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-     "declaration": true,                     /* Generates corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./dist/index.js",            /* Concatenate and emit output to single file. */
-     "outDir": "./dist",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "target": "es2017",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true
   },
   "include": [
     "./src/**.ts"


### PR DESCRIPTION
If use tea-school with Docker, you must use --no-sandbox parameters for Puppeteer. 
I add has second parameters a puppeters parameters.

For example i edit README.md file and add Use with Docker section.
